### PR TITLE
Don't speicfy version-stage and version-id of Secrets Manager

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -2,8 +2,8 @@ version: 0.2
 
 env:
   secrets-manager:
-    SLACK_TOKEN: codebuild/keyakizaka46-schedule-slack-notifier:SLACK_TOKEN:AWSCURRENT:112def9c-a5e2-4348-9540-e412a7304b62
-    SLACK_CHANNEL: codebuild/keyakizaka46-schedule-slack-notifier:SLACK_CHANNEL:AWSCURRENT:112def9c-a5e2-4348-9540-e412a7304b62
+    SLACK_TOKEN: codebuild/keyakizaka46-schedule-slack-notifier:SLACK_TOKEN
+    SLACK_CHANNEL: codebuild/keyakizaka46-schedule-slack-notifier:SLACK_CHANNEL
 
 phases:
   pre_build:


### PR DESCRIPTION
https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html

>If you don't specify a version stage or version ID, the default is to retrieve the version with the version stage value of AWSCURRENT.